### PR TITLE
ROCANA-5110 Fix imports in go-avro

### DIFF
--- a/examples/bufferedEncoder/bufferedEncoder.go
+++ b/examples/bufferedEncoder/bufferedEncoder.go
@@ -21,7 +21,7 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"github.com/linkedin/goavro"
+	"github.com/scalingdata/goavro"
 	"io"
 	"log"
 )

--- a/examples/decodeRecord/decodeRecord.go
+++ b/examples/decodeRecord/decodeRecord.go
@@ -21,7 +21,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/linkedin/goavro"
+	"github.com/scalingdata/goavro"
 	"log"
 )
 

--- a/examples/encodeRecord/encodeRecord.go
+++ b/examples/encodeRecord/encodeRecord.go
@@ -20,7 +20,7 @@ package main
 
 import (
 	"bytes"
-	"github.com/linkedin/goavro"
+	"github.com/scalingdata/goavro"
 	"log"
 )
 

--- a/examples/file/reader/reader.go
+++ b/examples/file/reader/reader.go
@@ -20,7 +20,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/linkedin/goavro"
+	"github.com/scalingdata/goavro"
 	"io"
 	"log"
 	"os"

--- a/examples/file/writer/writer.go
+++ b/examples/file/writer/writer.go
@@ -19,7 +19,7 @@
 package main
 
 import (
-	"github.com/linkedin/goavro"
+	"github.com/scalingdata/goavro"
 	"io"
 	"log"
 	"os"

--- a/examples/generic_datum/generic_datum.go
+++ b/examples/generic_datum/generic_datum.go
@@ -21,7 +21,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/linkedin/goavro"
+	"github.com/scalingdata/goavro"
 	"log"
 )
 

--- a/examples/nestedRecords/nestedRecords.go
+++ b/examples/nestedRecords/nestedRecords.go
@@ -21,7 +21,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/linkedin/goavro"
+	"github.com/scalingdata/goavro"
 	"log"
 )
 

--- a/examples/net/client/client.go
+++ b/examples/net/client/client.go
@@ -20,7 +20,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/linkedin/goavro"
+	"github.com/scalingdata/goavro"
 	"log"
 	"net"
 )

--- a/examples/net/server/server.go
+++ b/examples/net/server/server.go
@@ -19,7 +19,7 @@
 package main
 
 import (
-	"github.com/linkedin/goavro"
+	"github.com/scalingdata/goavro"
 	"log"
 	"net"
 )

--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -21,9 +21,9 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"github.com/scalingdata/snappy-go/snappy"
 	"compress/flate"
 	"fmt"
+	"github.com/scalingdata/snappy"
 	"io"
 	"io/ioutil"
 )

--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -21,9 +21,9 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"github.com/scalingdata/snappy-go/snappy"
 	"compress/flate"
 	"fmt"
+	"github.com/scalingdata/snappy"
 	"io"
 	"log"
 	"math/rand"

--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -317,10 +317,7 @@ func compressor(fw *Writer, toCompress <-chan *writerBlock, toWrite chan<- *writ
 		}
 	case CompressionSnappy:
 		for block := range toCompress {
-			block.compressed, block.err = snappy.Encode(block.compressed, block.encoded.Bytes())
-			if block.err != nil {
-				block.err = fmt.Errorf("cannot compress: %v", block.err)
-			}
+			block.compressed = snappy.Encode(block.compressed, block.encoded.Bytes())
 			toWrite <- block
 		}
 	}


### PR DESCRIPTION
- There were a few references to `github.com/linkedin/goavro` in the examples, which caused it to be pulled in for Jenkins tests. Replace all of these.
- Use the `github.com/scalingdata/snappy` repo for snappy, instead of the old `snappy-go` clone.

This gets the go-goavro Jenkins job back to passing.
